### PR TITLE
Add support for server passwords

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -10,6 +10,7 @@
 	"local_addr":		"",			// optional
 	"server":		"chat.freenode.net",
 	"server_port":		6667,			// optional
+	"server_password":	""			// optional; password to use when connecting to restricted servers(or bouncers)
 	"ipv6":			false,			// optional
 
 	"superadmin":		"jast",			// magically authorized to do everything

--- a/gitinfo-irc.pl
+++ b/gitinfo-irc.pl
@@ -64,6 +64,7 @@ our $irc = POE::Component::IRC::State->spawn(
 	'Nick'		=> $config->{nick},
 	'Username'	=> $config->{username},
 	'Ircname'	=> $config->{realname},
+        'Password'      => $config->{server_password},
 	'LocalAddr'	=> $config->{local_addr},
 	'useipv6'	=> $config->{ipv6},
 	'Raw'		=> 1,


### PR DESCRIPTION
Attempt to pass an IRC server password when initializing the connection.
This helps with restricted servers, or IRC bouncers(such as ZNC) which
identify the user using this string.

Signed-off-by: Eugene E. Kashpureff Jr eugene@kashpureff.org
