### PR TITLE
Syntax errorfixes.

### DIFF
--- a/plugin.pm
+++ b/plugin.pm
@@ -16,7 +16,7 @@ sub init {
 			for (split(/\s+/, $args[2])) {
 				BotDb::add_priv(lc($args[1]), lc($_));
 			}
-		} elsif ($args[0] =~ /^(?:remove|rm|del|delete)$) {
+		} elsif ($args[0] =~ /^(?:remove|rm|del|delete)$/) {
 			for (split(/\s+/, $args[2])) {
 				BotDb::del_priv(lc($args[1]), lc($_));
 			}

--- a/plugins/join.pm
+++ b/plugins/join.pm
@@ -20,7 +20,7 @@ use POE;
 				return;
 			}
 			if ($channel !~ /^#\S+$/) {
-				BotIrc::send_noise("I'm not particularly strict about channel names but you definitely didn't pass me a valid one there.")
+				BotIrc::send_noise("I'm not particularly strict about channel names but you definitely didn't pass me a valid one there.");
 				return;
 			}
 			if (!exists $BotIrc::config->{channel}{lc $channel}) {


### PR DESCRIPTION
Missing / and ; prevented loading of the 'join' plugin or even loading
plugins at all. Does upstream even test these things?

Signed-off-by: Eugene E. Kashpureff Jr eugene@kashpureff.org
